### PR TITLE
QOL docker-compose.yml fixes

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,9 +3,10 @@ version: "3.8"
 services:
   neonlink:
     image: alexscifier/neonlink
+    container_name: neonlink
     volumes:
       - ./bookmarks.sqlite:/app/db/bookmarks.sqlite
       - ./background:/app/public/static/media/background
-    restart: always
+    restart: unless-stopped
     ports:
       - "80:3333"


### PR DESCRIPTION
firstly, `restart: always` will keep restarting when an error occurs, its usually better to stop the container upon crash and the container_name variable just keeps the container name pretty