### PR TITLE
Fix typo in `interfaceTab.jsx`

### DIFF
--- a/frontend/src/pages/settings/tabs/interfaceTab/interfaceTab.jsx
+++ b/frontend/src/pages/settings/tabs/interfaceTab/interfaceTab.jsx
@@ -120,7 +120,7 @@ export default function InterfaceTab() {
       items: [
         {
           title: "Use image as background",
-          description: "Use image url as background of dashboad",
+          description: "Use image url as background of dashboard",
           icon: <PhotoIcon />,
           input: (
             <SwitchButton


### PR DESCRIPTION
Fix typo: "dashboad" -> "dashboard"